### PR TITLE
fix: convert USE_RELOADLY_SANDBOX to bool

### DIFF
--- a/functions/helpers.ts
+++ b/functions/helpers.ts
@@ -21,7 +21,7 @@ export interface ReloadlyAuthResponse {
 }
 
 export async function getAccessToken(env: Env): Promise<AccessToken> {
-  console.log("Using Reloadly Sandbox:", env.USE_RELOADLY_SANDBOX !== "false");
+  console.log("Using Reloadly Sandbox:", JSON.parse(env.USE_RELOADLY_SANDBOX));
 
   const url = "https://auth.reloadly.com/oauth/token";
   const options = {
@@ -31,7 +31,7 @@ export async function getAccessToken(env: Env): Promise<AccessToken> {
       client_id: env.RELOADLY_API_CLIENT_ID,
       client_secret: env.RELOADLY_API_CLIENT_SECRET,
       grant_type: "client_credentials",
-      audience: env.USE_RELOADLY_SANDBOX === "false" ? "https://giftcards.reloadly.com" : "https://giftcards-sandbox.reloadly.com",
+      audience: JSON.parse(env.USE_RELOADLY_SANDBOX) ? "https://giftcards-sandbox.reloadly.com" : "https://giftcards.reloadly.com",
     }),
   };
 
@@ -40,7 +40,7 @@ export async function getAccessToken(env: Env): Promise<AccessToken> {
     const successResponse = (await res.json()) as ReloadlyAuthResponse;
     return {
       token: successResponse.access_token,
-      isSandbox: env.USE_RELOADLY_SANDBOX !== "false",
+      isSandbox: JSON.parse(env.USE_RELOADLY_SANDBOX),
     };
   }
   throw `Getting access token failed: ${JSON.stringify(await res.json())}`;


### PR DESCRIPTION
I was trying to run `pay.ubq.fi` with production reloadly credentials locally and somehow `env.USE_RELOADLY_SANDBOX` ends up to be of boolean type instead of a string declared [here](https://github.com/rndquu/pay.ubq.fi/blob/baab92ae68422dce27ec0a14ba0261f25f89b1a4/functions/helpers.ts#L11). Hence [this](https://github.com/EresDevOrg/gift-card-pay.ubq.fi/blob/276956e20bfcdf80117e6b96c474da77f54235f4/wrangler.toml#L5) option didn't really work as expected because [here](https://github.com/EresDevOrg/gift-card-pay.ubq.fi/blob/276956e20bfcdf80117e6b96c474da77f54235f4/functions/helpers.ts#L34) boolean type is compared with a string type which always ended up in a `false` thus always working with a sandbox environment.

The `JSON.parse()` approach is pretty bool/string agnostic for testing locally (when `env.USE_RELOADLY_SANDBOX` ends up to be of boolean type) or via CI ([example](https://github.com/EresDevOrg/gift-card-pay.ubq.fi/blob/276956e20bfcdf80117e6b96c474da77f54235f4/.github/workflows/cypress-testing.yml#L42) where `USE_RELOADLY_SANDBOX` is a string).